### PR TITLE
feat(csvstorage): config timeouts cliente-WS

### DIFF
--- a/fuentes/inside-services/src/main/java/es/mpt/dsic/inside/service/csvstorage/impl/InsideCsvStorageMtomImpl.java
+++ b/fuentes/inside-services/src/main/java/es/mpt/dsic/inside/service/csvstorage/impl/InsideCsvStorageMtomImpl.java
@@ -28,6 +28,10 @@ import javax.xml.ws.soap.MTOMFeature;
 import org.apache.axiom.attachments.ByteArrayDataSource;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.cxf.endpoint.Client;
+import org.apache.cxf.frontend.ClientProxy;
+import org.apache.cxf.transport.http.HTTPConduit;
+import org.apache.cxf.transports.http.configuration.HTTPClientPolicy;
 // import org.apache.cxf.frontend.ClientProxy;
 // import org.apache.cxf.transport.http.HTTPConduit;
 // import org.apache.cxf.transports.http.configuration.HTTPClientPolicy;
@@ -56,7 +60,26 @@ public class InsideCsvStorageMtomImpl implements InsideCsvStorageMtomService {
 
   private Properties properties;
 
+  private Long connectionTimeout;
+  private Long receiveTimeout;
+
   private CSVDocumentMtomService csvDocumentMtomService;
+
+  public Long getConnectionTimeout() {
+    return connectionTimeout;
+  }
+
+  public void setConnectionTimeout(Long connectionTimeout) {
+    this.connectionTimeout = connectionTimeout;
+  }
+
+  public Long getReceiveTimeout() {
+    return receiveTimeout;
+  }
+
+  public void setReceiveTimeout(Long receiveTimeout) {
+    this.receiveTimeout = receiveTimeout;
+  }
 
   // @PostConstruct
   public void configure() {
@@ -67,6 +90,23 @@ public class InsideCsvStorageMtomImpl implements InsideCsvStorageMtomService {
         CSVDocumentMtomService_Service csvService = new CSVDocumentMtomService_Service(url);
 
         csvDocumentMtomService = csvService.getCSVDocumentMtomServicePort(new MTOMFeature());
+
+        Client client = ClientProxy.getClient(csvDocumentMtomService);
+        HTTPConduit httpConduit = (HTTPConduit) client.getConduit();
+        HTTPClientPolicy policy = null;
+        if (this.getConnectionTimeout() != null) {
+          policy = httpConduit.getClient();
+          policy.setConnectionTimeout(this.getConnectionTimeout());
+        }
+        if (this.getReceiveTimeout() != null) {
+          if (policy == null) {
+            policy = httpConduit.getClient();
+          }
+          policy.setReceiveTimeout(this.getReceiveTimeout());
+        }
+        if (policy != null) {
+          httpConduit.setClient(policy);
+        }
 
         if (Boolean.valueOf((properties.getProperty("csvstorage.imprimirMensaje")))) {
           BindingProvider bindingProvider = (BindingProvider) csvDocumentMtomService;

--- a/fuentes/inside-services/src/main/resources/es/mpt/dsic/inside/context/inside-csvstorage.xml
+++ b/fuentes/inside-services/src/main/resources/es/mpt/dsic/inside/context/inside-csvstorage.xml
@@ -35,5 +35,9 @@
  		<property name="properties"> 
  			<util:properties location="file:${config.path}/csvstorage.properties"/> 
  		</property> 
+		<property name="connectionTimeout" 
+			value="${csvstorage.cxf.client.connectionTimeout:#{null}}"/>
+		<property name="receiveTimeout" 
+			value="${csvstorage.cxf.client.receiveTimeout:#{null}}"/>
  	</bean>	   
 </beans>	

--- a/fuentes/inside-web/src/main/webapp/WEB-INF/web.xml
+++ b/fuentes/inside-web/src/main/webapp/WEB-INF/web.xml
@@ -13,8 +13,9 @@
    http://joinup.ec.europa.eu/software/page/eupl/licence-eupl -->
 
 <web-app xmlns="http://java.sun.com/xml/ns/j2ee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd"
-	version="2.4">
+	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+	xmlns:web="http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+	version="2.5">
 	<description>InSide WS</description>
 
 


### PR DESCRIPTION
Parametrización cliente de servicios web de CSV Storage mediante propiedades enhanced.

En fichero:
`file:${config.path}/enhanced_2-0-7-x.properties`
Propiedades y posibles valores:
`csvstorage.cxf.client.connectionTimeout=<valor_numérico_entero_positivo_en_milisegundos>`
`csvtorage.cxf.client.receiveTimeout=<valor_numérico_entero_positivo_en_milisegundos>`

Closes #25