### PR TITLE
Cambio de http a https para repos maven

### DIFF
--- a/fuentes/inside-mvn-base/pom.xml
+++ b/fuentes/inside-mvn-base/pom.xml
@@ -542,12 +542,12 @@
 	    <repository>
 	      <id>maven-mpt-es-libs-release</id>
 	      <name>maven-mpt-es-libs-release</name>
-		  <url>http://maven.mpt.es/artifactory/libs-release-local</url>
+		  <url>https://maven.mpt.es/artifactory/libs-release-local</url>
 	    </repository>
 	    <snapshotRepository>
 	      <id>maven-mpt-es-libs-snapshot</id>
 	      <name>maven-mpt-es-libs-snapshot</name>
-		  <url>http://maven.mpt.es/artifactory/libs-snapshot-local</url>
+		  <url>https://maven.mpt.es/artifactory/libs-snapshot-local</url>
 	    </snapshotRepository>
     </distributionManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
 	      </snapshots>
 	      <id>central</id>
 	      <name>Central Repository</name>
-	      <url>http://repo.maven.apache.org/maven2</url>
+	      <url>https://repo.maven.apache.org/maven2</url>
 	    </repository>
         </repositories>
 


### PR DESCRIPTION
http://maven.apache.org/docs/3.2.3/release-notes.html

También se ha cambiado para maven.mpt.es pero realmente no sé si este paso era necesario.