### PR TITLE
refactor(cxf): config timeouts clientes Eeutils

### DIFF
--- a/fuentes/eeutil-client/pom.xml
+++ b/fuentes/eeutil-client/pom.xml
@@ -48,5 +48,23 @@
         </snapshotRepository>
     </distributionManagement -->
     
+	<dependencies>
+		<!-- cxf para configurar interceptores logging -->
+		<dependency>
+			<groupId>org.apache.cxf</groupId>
+			<artifactId>cxf-rt-frontend-jaxws</artifactId>
+			<exclusions>
+				<exclusion>
+					<artifactId>jaxb-impl</artifactId>
+					<groupId>com.sun.xml.bind</groupId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<!-- cxf para configurar timeouts HTTP -->
+		<dependency>
+			<groupId>org.apache.cxf</groupId>
+			<artifactId>cxf-rt-transports-http</artifactId>
+		</dependency>
+	</dependencies>
     
 </project>

--- a/fuentes/eeutil-client/src/main/java/es/mpt/dsic/eeutil/client/util/CxfClientUtil.java
+++ b/fuentes/eeutil-client/src/main/java/es/mpt/dsic/eeutil/client/util/CxfClientUtil.java
@@ -1,0 +1,35 @@
+package es.mpt.dsic.eeutil.client.util;
+
+import org.apache.cxf.endpoint.Client;
+import org.apache.cxf.interceptor.LoggingInInterceptor;
+import org.apache.cxf.interceptor.LoggingOutInterceptor;
+import org.apache.cxf.transport.http.HTTPConduit;
+import org.apache.cxf.transports.http.configuration.HTTPClientPolicy;
+
+public class CxfClientUtil {
+
+  private CxfClientUtil() {
+    throw new IllegalStateException("Utility class");
+  }
+
+  public static void setupLoggingCxf(Client client, boolean loggingCxfEnabled,
+      int loggingCxfLimit) {
+    if (loggingCxfEnabled) {
+      client.getInInterceptors().add(loggingCxfLimit == 0 ? new LoggingInInterceptor()
+          : new LoggingInInterceptor(loggingCxfLimit));
+      client.getOutInterceptors().add(loggingCxfLimit == 0 ? new LoggingOutInterceptor()
+          : new LoggingOutInterceptor(loggingCxfLimit));
+    }
+  }
+
+  public static void setupTimeouts(Client client, Long connectionTimeout, Long receiveTimeout) {
+    HTTPConduit httpConduit = (HTTPConduit) client.getConduit();
+    HTTPClientPolicy policy = httpConduit.getClient();
+    // set time to wait for response in milliseconds. zero means unlimited
+    if (receiveTimeout != null)
+      policy.setReceiveTimeout(receiveTimeout);
+    if (connectionTimeout != null)
+      policy.setConnectionTimeout(connectionTimeout);
+  }
+
+}

--- a/fuentes/infofirma-service/pom.xml
+++ b/fuentes/infofirma-service/pom.xml
@@ -79,18 +79,6 @@
 			<artifactId>axiom-api</artifactId>
 			<version>1.2.5</version>
 		</dependency>
-		
-		<!-- cxf para interceptores logging -->
-		<dependency>
-			<groupId>org.apache.cxf</groupId>
-			<artifactId>cxf-rt-frontend-jaxws</artifactId>
-			<exclusions>
-				<exclusion>
-					<artifactId>jaxb-impl</artifactId>
-					<groupId>com.sun.xml.bind</groupId>
-				</exclusion>
-			</exclusions>
-		</dependency>
 	</dependencies>
 	
 	

--- a/fuentes/inside-services/src/main/java/es/mpt/dsic/inside/service/visualizacion/impl/InsideServiceVisualizacionImpl.java
+++ b/fuentes/inside-services/src/main/java/es/mpt/dsic/inside/service/visualizacion/impl/InsideServiceVisualizacionImpl.java
@@ -24,15 +24,13 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.cxf.endpoint.Client;
 import org.apache.cxf.frontend.ClientProxy;
-import org.apache.cxf.interceptor.LoggingInInterceptor;
-import org.apache.cxf.interceptor.LoggingOutInterceptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Required;
 import org.springframework.beans.factory.annotation.Value;
 import es.mpt.dsic.eeutil.client.model.DatosFirmados;
 import es.mpt.dsic.eeutil.client.operFirma.model.ResultadoValidacionInfo;
+import es.mpt.dsic.eeutil.client.util.CxfClientUtil;
 import es.mpt.dsic.eeutil.client.visDocExp.model.ApplicationLogin;
 import es.mpt.dsic.eeutil.client.visDocExp.model.DocumentoContenido;
 import es.mpt.dsic.eeutil.client.visDocExp.model.DocumentoEniConMAdicionales;
@@ -89,6 +87,10 @@ public class InsideServiceVisualizacionImpl implements InsideServiceVisualizacio
   private boolean eeutilsLoggingCxfEnabled;
   @Value("${eeutils.cxf.client.logging.interceptor.limit:0}")
   private Integer eeutilsLoggingCxfLimit;
+  @Value("${eeutils.cxf.client.connectionTimeout:#{null}}")
+  private Long eeutilsCxfConnectionTimeout;
+  @Value("${eeutils.cxf.client.receiveTimeout:#{null}}")
+  private Long eeutilsCxfReceiveTimeout;
   private EeUtilService port;
   private ApplicationLogin applicationLogin;
 
@@ -138,7 +140,10 @@ public class InsideServiceVisualizacionImpl implements InsideServiceVisualizacio
 
           port = ss.getEeUtilServiceImplPort();
 
-          enableLoggingCxf(ClientProxy.getClient(port));
+          CxfClientUtil.setupLoggingCxf(ClientProxy.getClient(port), eeutilsLoggingCxfEnabled,
+              eeutilsLoggingCxfLimit);
+          CxfClientUtil.setupTimeouts(ClientProxy.getClient(port), eeutilsCxfConnectionTimeout,
+              eeutilsCxfReceiveTimeout);
 
           applicationLogin = new ApplicationLogin();
           applicationLogin.setIdaplicacion(properties.getProperty("visualizacion.idaplicacion"));
@@ -182,15 +187,6 @@ public class InsideServiceVisualizacionImpl implements InsideServiceVisualizacio
       }
     }
     return activo;
-  }
-
-  private void enableLoggingCxf(Client client) {
-    if (eeutilsLoggingCxfEnabled) {
-      client.getInInterceptors().add(eeutilsLoggingCxfLimit == 0 ? new LoggingInInterceptor()
-          : new LoggingInInterceptor(eeutilsLoggingCxfLimit));
-      client.getOutInterceptors().add(eeutilsLoggingCxfLimit == 0 ? new LoggingOutInterceptor()
-          : new LoggingOutInterceptor(eeutilsLoggingCxfLimit));
-    }
   }
 
   @Override


### PR DESCRIPTION
Parametrización timeouts clientes servicios web de Eeutils mediante propiedades enhanced.

Incluye refactorización de a4e28a879b26ae64f394bdacb616b3d56ec87086 para eliminar duplicidcades de código.

En fichero:
  `file:${config.path}/enhanced_carm.properties`
Propiedades y posibles valores:
  `eeutils.cxf.client.connectionTimeout
   =<valor_numérico_entero_positivo_en_milisegundos>`
  `eeutils.cxf.client.receiveTimeout
   =<valor_numérico_entero_positivo_en_milisegundos>`

Closes #67, refactor #65.