### PR TITLE
refactor(eeutil-vis): Optimizar dml petición

### DIFF
--- a/fuentes/inside-services/src/main/java/es/mpt/dsic/inside/service/store/InsideServiceStore.java
+++ b/fuentes/inside-services/src/main/java/es/mpt/dsic/inside/service/store/InsideServiceStore.java
@@ -13,9 +13,8 @@ package es.mpt.dsic.inside.service.store;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.SortedMap;
-import javax.xml.bind.JAXBException;
-import javax.xml.stream.XMLStreamException;
 import es.mpt.dsic.inside.model.busqueda.consulta.ConsultaInside;
 import es.mpt.dsic.inside.model.busqueda.resultado.ResultadoBusquedaInside;
 import es.mpt.dsic.inside.model.busqueda.resultado.ResultadoBusquedaUsuario;
@@ -36,11 +35,9 @@ import es.mpt.dsic.inside.model.objetos.ObjetoUnidadOrganica;
 import es.mpt.dsic.inside.model.objetos.documento.ObjetoDocumentoInside;
 import es.mpt.dsic.inside.model.objetos.expediente.ObjetoAuditoriaAccesoDocumento;
 import es.mpt.dsic.inside.model.objetos.expediente.ObjetoAuditoriaToken;
-import es.mpt.dsic.inside.model.objetos.expediente.ObjetoComunicacionTokenExpediente;
 import es.mpt.dsic.inside.model.objetos.expediente.ObjetoEstructuraCarpetaInside;
 import es.mpt.dsic.inside.model.objetos.expediente.ObjetoExpedienteInside;
 import es.mpt.dsic.inside.model.objetos.expediente.ObjetoExpedienteToken;
-import es.mpt.dsic.inside.model.objetos.expediente.ObjetoSolicitudAccesoExpediente;
 import es.mpt.dsic.inside.model.objetos.filter.ObjetoFilterPageRequest;
 import es.mpt.dsic.inside.model.objetos.usuario.ObjetoInsideUsuario;
 import es.mpt.dsic.inside.service.store.exception.InsideServiceStoreException;
@@ -239,6 +236,9 @@ public interface InsideServiceStore {
       throws InsideServiceStoreException;
 
   public boolean existeUsuarioInsideConDir3(String dir3);
+
+  public Map<String, String> getMetadatoAdicionalDocumentos(List<String> idsEniDocumentos,
+      String nombreMetaAdic) throws InsideServiceStoreException;
 
   public ObjetoInsideDocumentoUnidad getDocumentoUnidad(String identificadorDocumento)
       throws InsideServiceStoreException;

--- a/fuentes/inside-services/src/main/java/es/mpt/dsic/inside/service/store/impl/hibernate/InsideServiceStoreHibernateImpl.java
+++ b/fuentes/inside-services/src/main/java/es/mpt/dsic/inside/service/store/impl/hibernate/InsideServiceStoreHibernateImpl.java
@@ -19,6 +19,7 @@ import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.StringTokenizer;
@@ -2577,6 +2578,32 @@ public class InsideServiceStoreHibernateImpl<I extends ObjetoInside<?>, E extend
       session.close();
     }
     return retorno;
+  }
+
+  @Override
+  public Map<String, String> getMetadatoAdicionalDocumentos(List<String> idsEniDocumentos,
+      String nombreMetaAdic) throws InsideServiceStoreException {
+    Session session = sessionFactory.openSession();
+    Map<String, String> metasAdicDocs = new HashMap<>();
+    try {
+      List<?> resultsRaw = session.createQuery(
+          "SELECT di.identificador, dimeta.valor FROM DocumentoInsideMetadatosAdicionales dimeta, DocumentoInside di "
+              + "WHERE dimeta.documentoInside.id = di.id AND di.identificador IN(:p1) AND dimeta.nombre = :p2")
+          .setParameterList("p1", idsEniDocumentos).setParameter("p2", nombreMetaAdic).list();
+      for (Object raw : resultsRaw) {
+        Object[] s = (Object[]) raw;
+        metasAdicDocs.put((String) s[0], (String) s[1]);
+      }
+    } catch (Exception e) {
+      throw new InsideServiceStoreException(
+          "Excepción obteniendo metadato adicional " + nombreMetaAdic + " en documentos "
+              + (idsEniDocumentos == null ? null : String.join(",", idsEniDocumentos)),
+          e);
+
+    } finally {
+      session.close();
+    }
+    return metasAdicDocs;
   }
 
   public ObjetoInsideDocumentoUnidad getDocumentoUnidad(String identificadorDocumento)

--- a/fuentes/inside-services/src/main/java/es/mpt/dsic/inside/service/store/impl/hibernate/InsideServiceStoreHibernatePersister.java
+++ b/fuentes/inside-services/src/main/java/es/mpt/dsic/inside/service/store/impl/hibernate/InsideServiceStoreHibernatePersister.java
@@ -14,10 +14,12 @@ package es.mpt.dsic.inside.service.store.impl.hibernate;
 import java.io.UnsupportedEncodingException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Set;
+import org.apache.commons.lang.time.DateFormatUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.hibernate.Criteria;
@@ -245,7 +247,8 @@ public class InsideServiceStoreHibernatePersister<I extends ObjetoInside<?>, E e
 
   private void saveExpediente(ExpedienteInside expedienteEntity, Session session,
       Object objectUnidad) throws InsideServiceStoreException {
-    logger.debug("Init saveExpediente");
+    logger.debug("Init saveExpediente " + expedienteEntity.getIdentificador() + ": "
+        + DateFormatUtils.ISO_TIME_NO_T_FORMAT.format(Calendar.getInstance().getTime()));
     logger.debug("Parameter <expedienteEntity>" + expedienteEntity.toString());
     Transaction tx = session.beginTransaction();
     try {
@@ -278,7 +281,8 @@ public class InsideServiceStoreHibernatePersister<I extends ObjetoInside<?>, E e
       throw new InsideServiceStoreException("Excepción almacenando Expediente en BBDD", e);
     }
 
-    logger.debug("End saveExpediente");
+    logger.debug("End saveExpediente " + expedienteEntity.getIdentificador() + ": "
+        + DateFormatUtils.ISO_TIME_NO_T_FORMAT.format(Calendar.getInstance().getTime()));
   }
 
   private void saveIndiceExpediente(ExpedienteInsideIndice indiceExpedienteEntity, Session session)


### PR DESCRIPTION
Cuando está a true la nueva propiedad, la recuperación del metadato
adicional nombre natural de todos los documentos del expediente
(interno) se obtienen en la misma consulta, para poder incluirlos en
el índice del expediente de la petición a la Eeutil-Vis-Docexp de
visualización del mismo en PDF.

Se modifica el logging, a nivel DEBUG, de los eventuales puntos
críticos restantes que pueden estar causando respuestas elevadas con
expedientes grandes (la llamada al servicio de visualización en sí,
que genera el PDF, y la persistencia de la nueva versión del
expediente en BD, para anotar y poder revisar tiempos de inicio y fin
mediante configuración de log4j).

En fichero:
file:${config.path}/enhanced_carm.properties
Propiedad y posibles valores:
eeutils.vis-docexp.exp.optimizar.dml.indice=<true|false>

Closes: #70