### PR TITLE
fix(eeutils): activación indep. orden ejecución

### DIFF
--- a/fuentes/infofirma-service/src/main/java/es/mpt/dsic/infofirma/service/impl/InfoFirmaServiceImpl.java
+++ b/fuentes/infofirma-service/src/main/java/es/mpt/dsic/infofirma/service/impl/InfoFirmaServiceImpl.java
@@ -159,8 +159,12 @@ public class InfoFirmaServiceImpl implements InfoFirmaService {
         dataHanlerFirmaContenido = new DataHandler(dataSourceFirmaContenido);
       }
 
+      logger.debug("Inicio operación eeutil-oper-firma/obtener información de firma "
+          + firma.getTipoFirma());
       InformacionFirma infoFirma = port.obtenerInformacionFirma(applicationLogin, dataHanlerFirma,
           opcionesWS, dataHanlerFirmaContenido);
+      logger.debug(
+          "Fin operación eeutil-oper-firma/obtener información de firma " + firma.getTipoFirma());
 
       if (!infoFirma.isEsFirma()) {
         throw new InfoFirmaServiceNoEsFirmaException(
@@ -263,8 +267,10 @@ public class InfoFirmaServiceImpl implements InfoFirmaService {
 
       ResultadoValidacionInfo validacionInfo;
 
+      logger.debug("Inicio operación eeutil-oper-firma/validación de firma " + tipoFirma);
       validacionInfo = port.validacionFirma(applicationLogin, dataHanlerFirma, tipoFirma,
           dataHanlerDatosFirmados);
+      logger.debug("Fin operación eeutil-oper-firma/validación de firma " + tipoFirma);
       return validacionInfo;
     } catch (InSideException e) {
       logger.debug("Error de validación de firma" + e);

--- a/fuentes/inside-services/src/main/java/es/mpt/dsic/inside/service/impl/InsideServiceSignerImpl.java
+++ b/fuentes/inside-services/src/main/java/es/mpt/dsic/inside/service/impl/InsideServiceSignerImpl.java
@@ -119,8 +119,11 @@ public class InsideServiceSignerImpl implements InsideServiceSigner {
         loginFirma = applicationLogin;
       }
 
+      logger.debug("Inicio operación eeutil-firma/firma fichero remota " + formatoFirma);
       salida = port.firmaFichero(loginFirma, de);
+      logger.debug("Fin operación eeutil-firma/firma fichero remota " + formatoFirma);
     } catch (Exception e) {
+      logger.debug("Error en operación eeutil-firma/firma fichero remota" + formatoFirma);
       throw new InSideServiceSignerException(
           "Se ha producido un error en la llamada al servicio de firma remota ", e);
     }
@@ -169,8 +172,11 @@ public class InsideServiceSignerImpl implements InsideServiceSigner {
         loginFirma = applicationLogin;
       }
 
+      logger.debug("Inicio operación eeutil-firma/firma fichero propertie remota " + nodeToSign);
       salida = port.firmaFicheroWithPropertie(loginFirma, de);
+      logger.debug("Fin operación eeutil-firma/firma fichero propertie remota " + nodeToSign);
     } catch (Exception e) {
+      logger.debug("Error en operación eeutil-firma/firma fichero propertie remota" + nodeToSign);
       throw new InSideServiceSignerException(
           "Se ha producido un error en la llamada al servicio de firma remota ", e);
     }
@@ -200,6 +206,7 @@ public class InsideServiceSignerImpl implements InsideServiceSigner {
   }
 
   public boolean isActivo() {
+    configureSigner();
     return activo;
   }
 

--- a/fuentes/inside-services/src/main/java/es/mpt/dsic/inside/service/store/impl/hibernate/InsideServiceStoreHibernatePersister.java
+++ b/fuentes/inside-services/src/main/java/es/mpt/dsic/inside/service/store/impl/hibernate/InsideServiceStoreHibernatePersister.java
@@ -14,12 +14,10 @@ package es.mpt.dsic.inside.service.store.impl.hibernate;
 import java.io.UnsupportedEncodingException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Set;
-import org.apache.commons.lang.time.DateFormatUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.hibernate.Criteria;
@@ -247,33 +245,47 @@ public class InsideServiceStoreHibernatePersister<I extends ObjetoInside<?>, E e
 
   private void saveExpediente(ExpedienteInside expedienteEntity, Session session,
       Object objectUnidad) throws InsideServiceStoreException {
-    logger.debug("Init saveExpediente " + expedienteEntity.getIdentificador() + ": "
-        + DateFormatUtils.ISO_TIME_NO_T_FORMAT.format(Calendar.getInstance().getTime()));
+    logger.debug("Init saveExpediente " + expedienteEntity.getIdentificador());
     logger.debug("Parameter <expedienteEntity>" + expedienteEntity.toString());
     Transaction tx = session.beginTransaction();
     try {
 
+      logger.debug("Init saveIndiceExpediente " + expedienteEntity.getIdentificador());
       saveIndiceExpediente(expedienteEntity.getExpedienteInsideIndice(), session);
+      logger.debug("End saveIndiceExpediente " + expedienteEntity.getIdentificador());
 
+      logger.debug("Init saveExpedienteEntity " + expedienteEntity.getIdentificador());
       session.saveOrUpdate(expedienteEntity);
+      logger.debug("End saveExpedienteEntity " + expedienteEntity.getIdentificador());
+      logger.debug("Init saveExpedienteUnidad " + expedienteEntity.getIdentificador());
       session.saveOrUpdate(objectUnidad);
+      logger.debug("End saveExpedienteUnidad " + expedienteEntity.getIdentificador());
 
+      logger.debug("Init saveIndiceExpedienteFirmas " + expedienteEntity.getIdentificador());
       for (ExpedienteInsideIndiceFirmas docFirma : expedienteEntity
           .getExpedienteInsideIndiceFirmases()) {
         session.saveOrUpdate(docFirma.getFirmaInside());
         session.saveOrUpdate(docFirma);
       }
+      logger.debug("End saveIndiceExpedienteFirmas " + expedienteEntity.getIdentificador());
+      logger.debug("Init saveExpedienteInteresados " + expedienteEntity.getIdentificador());
       for (ExpedienteInsideInteresado interesado : expedienteEntity
           .getExpedienteInsideInteresados()) {
         session.saveOrUpdate(interesado);
       }
+      logger.debug("End saveExpedienteInteresados " + expedienteEntity.getIdentificador());
+      logger.debug("Init saveExpedienteOrganos " + expedienteEntity.getIdentificador());
       for (ExpedienteInsideOrgano organo : expedienteEntity.getExpedienteInsideOrganos()) {
         session.saveOrUpdate(organo);
       }
+      logger.debug("End saveExpedienteOrganos " + expedienteEntity.getIdentificador());
+      logger
+          .debug("Init saveExpedienteMetadatosAdicionales " + expedienteEntity.getIdentificador());
       for (ExpedienteInsideMetadatosAdicionales metadato : expedienteEntity
           .getExpedienteInsideMetadatosAdicionaleses()) {
         session.saveOrUpdate(metadato);
       }
+      logger.debug("End saveExpedienteMetadatosAdicionales " + expedienteEntity.getIdentificador());
 
       tx.commit();
     } catch (Exception e) {
@@ -281,8 +293,7 @@ public class InsideServiceStoreHibernatePersister<I extends ObjetoInside<?>, E e
       throw new InsideServiceStoreException("Excepción almacenando Expediente en BBDD", e);
     }
 
-    logger.debug("End saveExpediente " + expedienteEntity.getIdentificador() + ": "
-        + DateFormatUtils.ISO_TIME_NO_T_FORMAT.format(Calendar.getInstance().getTime()));
+    logger.debug("End saveExpediente " + expedienteEntity.getIdentificador());
   }
 
   private void saveIndiceExpediente(ExpedienteInsideIndice indiceExpedienteEntity, Session session)

--- a/fuentes/inside-services/src/main/java/es/mpt/dsic/inside/service/validacionENI/impl/ConsumidorValidacionENI.java
+++ b/fuentes/inside-services/src/main/java/es/mpt/dsic/inside/service/validacionENI/impl/ConsumidorValidacionENI.java
@@ -102,6 +102,7 @@ public class ConsumidorValidacionENI {
   protected static final Log logger = LogFactory.getLog(ConsumidorValidacionENI.class);
 
   public boolean isActivo() {
+    configure();
     return this.activo;
   }
 
@@ -227,8 +228,10 @@ public class ConsumidorValidacionENI {
 
     if (validaciones.isValidaFirma()) {
       if (isActivo()) {
+        logger.debug("Inicio operación eeutil-vis-docexp/validar firma documento ENI ");
         RespuestaValidacionENI respuestValidarFirma =
             scMtom.validarFirmaDocumentoENI(aplicacionInfo, documentoENI);
+        logger.debug("Fin operación eeutil-vis-docexp/validar firma documento ENI ");
         listaDetalles.addAll(respuestValidarFirma.getDetalle());
       } else {
         logger.error("El servicio no se encuentra activo");
@@ -303,8 +306,10 @@ public class ConsumidorValidacionENI {
       ByteArrayDataSource dataSource = new ByteArrayDataSource(docuemnto);
       docEntrada.setContenido(new DataHandler(dataSource));
 
+      logger.debug("Inicio operación eeutil-vis-docexp/validar firma documento ENI");
       RespuestaValidacionENI respuesta =
           scMtom.validarFirmaDocumentoENI(aplicacionInfo, docEntrada);
+      logger.debug("Fin operación eeutil-vis-docexp/validar firma documento ENI");
 
       logger.debug("Fin validaFirmaDocumentoENI");
       return formatValidacionENIDocumentoInside(respuesta);
@@ -500,8 +505,10 @@ public class ConsumidorValidacionENI {
       ByteArrayDataSource dataSource = new ByteArrayDataSource(expediente);
       expEntrada.setContenido(new DataHandler(dataSource));
 
+      logger.debug("Inicio operación eeutil-vis-docexp/validar firma expediente ENI");
       RespuestaValidacionENI respuesta =
           scMtom.validarFirmaExpedienteENI(aplicacionInfo, expEntrada);
+      logger.debug("Fin operación eeutil-vis-docexp/validar firma expediente ENI");
 
       logger.debug("Fin validaFirmaExpedienteENI");
       return formatValidacionENIExpedienteInside(respuesta);

--- a/fuentes/inside-services/src/main/java/es/mpt/dsic/inside/service/visualizacion/impl/InsideServiceVisualizacionImpl.java
+++ b/fuentes/inside-services/src/main/java/es/mpt/dsic/inside/service/visualizacion/impl/InsideServiceVisualizacionImpl.java
@@ -16,7 +16,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -26,7 +25,6 @@ import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.time.DateFormatUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.cxf.frontend.ClientProxy;
@@ -217,16 +215,15 @@ public class InsideServiceVisualizacionImpl implements InsideServiceVisualizacio
     try {
       // Llamada al servicio
       logger.debug("Inicio operación eeutil-vis-docexp/visualizar expediente "
-          + itemExpediente.getIdentificador() + ": "
-          + DateFormatUtils.ISO_TIME_NO_T_FORMAT.format(Calendar.getInstance().getTime()));
+          + itemExpediente.getIdentificador());
       salida = port.visualizar(applicationLogin, itemExpediente, oVisualizacion);
+      logger.debug("Fin operación eeutil-vis-docexp/visualizar expediente "
+          + itemExpediente.getIdentificador());
     } catch (Exception t) {
+      logger.error("Error en operación eeutil-vis-docexp/visualizar expediente "
+          + itemExpediente.getIdentificador());
       throw new InsideServiceVisualizacionException("Error al obtener la visualización del índice",
           t);
-    } finally {
-      logger.debug("Fin operación eeutil-vis-docexp/visualizar expediente "
-          + itemExpediente.getIdentificador() + ": "
-          + DateFormatUtils.ISO_TIME_NO_T_FORMAT.format(Calendar.getInstance().getTime()));
     }
 
     // Rellenamos el objeto que contiene la visualización del índice.
@@ -336,6 +333,7 @@ public class InsideServiceVisualizacionImpl implements InsideServiceVisualizacio
    * Devuelve true si el servicio está activo, false en caso contrario
    */
   public boolean isActivo() {
+    configure();
     return this.activo;
   }
 


### PR DESCRIPTION
Corregir el fallo, en la recepción de la configuración de la
activación de los servicios Eeutil-Firma y Eeutil-Vis-Docexp, para
que se haga efectiva sin que dependa del orden de ejecución, de según
qué partes del código de la aplicación.

Relacionado con #70, se amplía el logging, a nivel DEBUG, de todas
las llamadas a los servicios de Eeutils que se invocan desde las
operaciones de Web Services, así como la parte del código para el
versionado del expediente ENI en base de datos (cuando sufre una
modificación), para anotar y poder revisar tiempos, de inicio y fin,
mediante configuración de log4j.

Closes: #75